### PR TITLE
Validate that sigv4a is modeled on service

### DIFF
--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/valid/eventbridge-tests.errors
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/valid/eventbridge-tests.errors
@@ -1,3 +1,4 @@
 [WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
 [WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#endpointTests | UnstableTrait
 [WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#clientContextParams | UnstableTrait
+[ERROR] example#FizzBuzz: Sigv4a auth trait must be applied to the service. | RuleSetAuthSchemes

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/valid/eventbridge.smithy
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/valid/eventbridge.smithy
@@ -2,6 +2,8 @@ $version: "2.0"
 
 namespace example
 
+use aws.auth#sigv4
+use aws.auth#sigv4a
 use smithy.rules#clientContextParams
 use smithy.rules#endpointRuleSet
 
@@ -335,4 +337,7 @@ use smithy.rules#endpointRuleSet
 @clientContextParams(
   endpointId: {type: "string", documentation: "docs"}
 )
+@auth([sigv4, sigv4a])
+@sigv4(name: "fizzbuzz")
+@sigv4a(name: "fizzbuzz")
 service FizzBuzz {}

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/AuthSchemeValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/AuthSchemeValidator.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import software.amazon.smithy.model.FromSourceLocation;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.rulesengine.language.syntax.Identifier;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.literal.Literal;
@@ -24,12 +26,16 @@ public interface AuthSchemeValidator extends Predicate<String> {
      * Validates that the provided {@code authScheme} matches required modeling behavior,
      * emitting events for any failures.
      *
+     * @param model the model being validated.
+     * @param serviceShape service being validated.
      * @param authScheme an authorization scheme parameter set.
      * @param sourceLocation the location of the authorization scheme to generate events from.
      * @param emitter a function to emit {@link ValidationEvent}s for validation failures.
      * @return a list of validation events.
      */
     List<ValidationEvent> validateScheme(
+            Model model,
+            ServiceShape serviceShape,
             Map<Identifier, Literal> authScheme,
             FromSourceLocation sourceLocation,
             BiFunction<FromSourceLocation, String, ValidationEvent> emitter);


### PR DESCRIPTION

#### Background
* Adds validation that when sigv4a is used as an authscheme in endpoint rules that it is also modeled on the service.

#### Testing
* Update model/error files.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
